### PR TITLE
Introduce more error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ impl Email {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn from_vec(data: Vec<u8>) -> Result<Self> {
-        let (normalized_data, fields) = normalize_email(&data);
+        let (normalized_data, fields) = normalize_email(&data)?;
         let body_index = find_empty_line(&normalized_data).unwrap_or(normalized_data.len());
         let email_filename_gen = Arc::new(Mutex::new(EmailFilenameGenerator::new()));
 


### PR DESCRIPTION
This is a WIP changeset to remove all `unwrap()` calls in the parser.

I found that your parser does some `unwrap()`ing where there could be `None` or `Err(_)` objects and thus it might panic. I did not experience any panic on my 41k Mails I ran the parser on, but better safe than sorry, right?

I am not done with this patchset, as some stuff needs careful refactoring - I propose it anyways to hear what you think and whether you'd like to include such changes in your codebase.