### PR TITLE
Add function to get all header keys from Email object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,8 +274,20 @@ impl Email {
         self.fields.get(&name.to_lowercase()).map(|v| v[0].as_str())
     }
 
-    pub fn header_keys(&self) -> Vec<&String> {
-        self.fields.keys().collect()
+    /// Returns all names of header fields found in the Email
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use mda::Email;
+    /// let email = Email::from_stdin()?;
+    /// for name in email.header_field_names() {
+    ///     println!("{}: {:?}", name, email.header_field(name));
+    /// }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn header_field_names(&self) -> Vec<&str> {
+        self.fields.keys().map(::std::ops::Deref::deref).collect()
     }
 
     /// Returns the values from all occurrences of a header field, if present.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,10 @@ impl Email {
         self.fields.get(&name.to_lowercase()).map(|v| v[0].as_str())
     }
 
+    pub fn header_keys(&self) -> Vec<&String> {
+        self.fields.keys().collect()
+    }
+
     /// Returns the values from all occurrences of a header field, if present.
     ///
     /// # Example

--- a/tests/test_fields.rs
+++ b/tests/test_fields.rs
@@ -133,3 +133,15 @@ fn header_using_crlf() {
          thirsdcc <secondcc@destination.com>"
     );
 }
+
+#[test]
+fn find_all_header_fields() {
+    let email = Email::from_vec(TEST_EMAIL_CRLF.to_string().into_bytes()).unwrap();
+
+    assert!(
+        email.header_field_names()
+            .iter()
+            .all(|name| email.header_field(name).is_some())
+    );
+}
+


### PR DESCRIPTION
This is helpful if the user of the `Email` object does not know which headers exist.